### PR TITLE
chore(deps): bump https://github.com/muirp/riderforest-golang.git 

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,3 +3,4 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [muirp/demo111](https://github.com/muirp/demo111.git) |  | []() | 
+[muirp/riderforest-golang](https://github.com/muirp/riderforest-golang.git) |  | []() | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -5,3 +5,9 @@ dependencies:
   url: https://github.com/muirp/demo111.git
   version: ""
   versionURL: ""
+- host: github.com
+  owner: muirp
+  repo: riderforest-golang
+  url: https://github.com/muirp/riderforest-golang.git
+  version: ""
+  versionURL: ""

--- a/repositories/templates/muirp-riderforest-golang-sr.yaml
+++ b/repositories/templates/muirp-riderforest-golang-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: muirp
+    provider: github
+    repository: riderforest-golang
+  name: muirp-riderforest-golang
+spec:
+  description: Imported application for muirp/riderforest-golang
+  httpCloneURL: https://github.com/muirp/riderforest-golang.git
+  org: muirp
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: riderforest-golang
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/muirp/riderforest-golang.git


### PR DESCRIPTION
Update [muirp/riderforest-golang](https://github.com/muirp/riderforest-golang.git) 

Command run was `jx create quickstart --git-public=true -f go --org muirp`